### PR TITLE
[BD-26][EDUCATOR-5808] Add additional data to mfe API responses

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -100,7 +100,14 @@ def get_proctoring_settings_by_exam_id(exam_id):
         except NotImplementedError as error:
             log.exception(str(error))
             raise BackendProviderNotConfigured(str(error)) from error
-        proctoring_settings_data['exam_proctoring_backend'] = provider.get_proctoring_config()
+        proctoring_settings_data.update({
+            'exam_proctoring_backend': provider.get_proctoring_config(),
+            'provider_tech_support_email': provider.tech_support_email,
+            'provider_tech_support_phone': provider.tech_support_phone,
+            'provider_name': provider.verbose_name,
+            'learner_notification_from_email': provider.learner_notification_from_email,
+            'integration_specific_email': get_integration_specific_email(provider),
+        })
     return proctoring_settings_data
 
 
@@ -618,7 +625,7 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
     attempt_data = {
         'in_timed_exam': True,
         'taking_as_proctored': attempt['taking_as_proctored'],
-        'exam_type': get_exam_type(provider, attempt),
+        'exam_type': get_exam_type(exam, provider)['humanized_type'],
         'exam_display_name': exam['exam_name'],
         'exam_url_path': exam_url_path,
         'time_remaining_seconds': time_remaining_seconds,

--- a/edx_proctoring/tests/test_mfe_views.py
+++ b/edx_proctoring/tests/test_mfe_views.py
@@ -79,6 +79,7 @@ class ProctoredExamAttemptsMFEViewTests(ProctoredExamTestCase):
         assert 'active_attempt' in response_data and response_data['active_attempt']
         self.assertHasExamData(response_data, has_attempt=True)
         self.assertEqual(exam_data['attempt']['exam_url_path'], self.expected_exam_url)
+        self.assertEqual(exam_data['type'], 'proctored')
 
     def test_get_started_timed_exam_attempts_data(self):
         """
@@ -117,6 +118,7 @@ class ProctoredExamAttemptsMFEViewTests(ProctoredExamTestCase):
         assert 'active_attempt' in response_data and not response_data['active_attempt']
         assert 'prerequisite_status' in exam_data
         self.assertHasExamData(response_data, has_attempt=False)
+        self.assertEqual(exam_data['type'], 'proctored')
 
     def test_get_exam_attempts_data_after_exam_is_submitted(self):
         """
@@ -133,6 +135,7 @@ class ProctoredExamAttemptsMFEViewTests(ProctoredExamTestCase):
         self.assertHasExamData(response_data, has_attempt=True)
         self.assertEqual(exam_data['attempt']['exam_url_path'], self.expected_exam_url)
         self.assertEqual(exam_data['attempt']['attempt_status'], ProctoredExamStudentAttemptStatus.submitted)
+        self.assertEqual(exam_data['type'], 'proctored')
 
     def test_no_exam_data_returned_for_non_exam_sequence(self):
         """

--- a/edx_proctoring/utils.py
+++ b/edx_proctoring/utils.py
@@ -302,11 +302,26 @@ def get_visibility_check_date(course_schedule, usage_key):
     return visibility_check_date
 
 
-def get_exam_type(provider, attempt):
-    """ Helper that returns exam type string by backend provider and exam attempt params. """
-    return (
-        _('a timed exam') if not attempt['taking_as_proctored'] else
-        (_('a proctored exam') if not attempt['is_sample_attempt'] else
-         (_('an onboarding exam') if (provider and provider.supports_onboarding) else
-          _('a practice exam')))
-    )
+def get_exam_type(exam, provider):
+    """ Helper that returns exam type and humanized name by backend provider and exam params. """
+    is_practice_exam = exam['is_proctored'] and exam['is_practice_exam']
+    is_timed_exam = not exam['is_proctored'] and not exam['is_practice_exam']
+
+    if is_timed_exam:
+        exam_type = 'timed'
+        humanized_type = _('a timed exam')
+    elif is_practice_exam:
+        if provider and provider.supports_onboarding:
+            exam_type = 'onboarding'
+            humanized_type = _('an onboarding exam')
+        else:
+            exam_type = 'practice'
+            humanized_type = _('a practice exam')
+    else:
+        exam_type = 'proctored'
+        humanized_type = _('a proctored exam')
+
+    return {
+        'type': exam_type,
+        'humanized_type': humanized_type,
+    }

--- a/edx_proctoring/utils.py
+++ b/edx_proctoring/utils.py
@@ -307,19 +307,15 @@ def get_exam_type(exam, provider):
     is_practice_exam = exam['is_proctored'] and exam['is_practice_exam']
     is_timed_exam = not exam['is_proctored'] and not exam['is_practice_exam']
 
+    exam_type, humanized_type = 'proctored', _('a proctored exam')
+
     if is_timed_exam:
-        exam_type = 'timed'
-        humanized_type = _('a timed exam')
+        exam_type, humanized_type = 'timed', _('a timed exam')
     elif is_practice_exam:
         if provider and provider.supports_onboarding:
-            exam_type = 'onboarding'
-            humanized_type = _('an onboarding exam')
+            exam_type, humanized_type = 'onboarding', _('an onboarding exam')
         else:
-            exam_type = 'practice'
-            humanized_type = _('a practice exam')
-    else:
-        exam_type = 'proctored'
-        humanized_type = _('a proctored exam')
+            exam_type, humanized_type = 'practice', _('a practice exam')
 
     return {
         'type': exam_type,

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -85,6 +85,7 @@ from edx_proctoring.statuses import (
 )
 from edx_proctoring.utils import (
     AuthenticatedAPIView,
+    get_exam_type,
     get_time_remaining_for_attempt,
     get_visibility_check_date,
     humanized_time,
@@ -238,7 +239,9 @@ class ProctoredExamAttemptView(ProctoredAPIView):
                 exam.update({'attempt': attempt_data})
             except ProctoredExamNotFoundException:
                 exam = {}
-
+        if exam:
+            provider = get_backend_provider(exam)
+            exam['type'] = get_exam_type(exam, provider)['type']
         response_dict = {
             'exam': exam,
             'active_attempt': active_attempt_data,


### PR DESCRIPTION
Updated proctoring setting API to return additional proctoring service data and also updated exam API to return type of the exam

[YouTrack](https://youtrack.raccoongang.com/issue/OeX_Proctoring-198)
[JIRA](https://openedx.atlassian.net/browse/EDUCATOR-5808)

NOTE: should be merged together with https://github.com/raccoongang/frontend-lib-special-exams/pull/27