### PR TITLE
[BD-26][EDUCATOR-5808] Check prerequisites only for proctored exams

### DIFF
--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -230,8 +230,10 @@ class ProctoredExamAttemptView(ProctoredAPIView):
                         attempt.get('id'),
                         is_learning_mfe=is_learning_mfe
                     )
-                # exam hasn't started yet and is proctored so check if prerequisites are satisfied
-                elif exam['is_proctored']:
+                # Exam hasn't started yet and is proctored so check if prerequisites are satisfied.
+                # We only do this for proctored exam hence additional check 'not exam['is_practice_exam']',
+                # meaning we do not check prerequisites for practice or onboarding exams
+                elif exam['is_proctored'] and not exam['is_practice_exam']:
                     exam = check_prerequisites(exam, request.user.id)
                 exam.update({'attempt': attempt_data})
             except ProctoredExamNotFoundException:


### PR DESCRIPTION
Check for prerequisites only if exam is proctored (previously we were doing check for practice and onboarding also)

[YouTrack](https://youtrack.raccoongang.com/issue/OeX_Proctoring-197)
[JIRA](https://openedx.atlassian.net/browse/EDUCATOR-5808)