### PR TITLE
[BD-26][EDUCATOR-5808] Extend MFE API to return additional data for expired and onboarding error pages

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -11,7 +11,6 @@ from datetime import datetime, timedelta
 
 import pytz
 from opaque_keys import InvalidKeyError
-from opaque_keys.edx.keys import CourseKey, UsageKey
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -65,6 +64,7 @@ from edx_proctoring.utils import (
     humanized_time,
     is_reattempting_exam,
     obscured_user_id,
+    resolve_exam_url_for_learning_mfe,
     verify_and_add_wait_deadline
 )
 
@@ -615,9 +615,7 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
     # resolve the LMS url, note we can't assume we're running in
     # a same process as the LMS
     if is_learning_mfe:
-        course_key = CourseKey.from_string(exam['course_id'])
-        usage_key = UsageKey.from_string(exam['content_id'])
-        exam_url_path = '{}/course/{}/{}'.format(settings.LEARNING_MICROFRONTEND_URL, course_key, usage_key)
+        exam_url_path = resolve_exam_url_for_learning_mfe(exam['course_id'], exam['content_id'])
 
     else:
         exam_url_path = reverse('jump_to', args=[exam['course_id'], exam['content_id']])

--- a/edx_proctoring/utils.py
+++ b/edx_proctoring/utils.py
@@ -12,7 +12,7 @@ from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthenticat
 from edx_when import api as when_api
 from eventtracking import tracker
 from opaque_keys import InvalidKeyError
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
@@ -321,3 +321,11 @@ def get_exam_type(exam, provider):
         'type': exam_type,
         'humanized_type': humanized_type,
     }
+
+
+def resolve_exam_url_for_learning_mfe(course_id, content_id):
+    """ Helper that builds the url to the exam for the MFE app learning. """
+    course_key = CourseKey.from_string(course_id)
+    usage_key = UsageKey.from_string(content_id)
+    url = '{}/course/{}/{}'.format(settings.LEARNING_MICROFRONTEND_URL, course_key, usage_key)
+    return url

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -242,10 +242,10 @@ class ProctoredExamAttemptView(ProctoredAPIView):
                 # proctored exam we need to navigate them to it with a link
                 if (exam['is_proctored'] and attempt_data and
                         attempt_data['attempt_status'] in ProctoredExamStudentAttemptStatus.onboarding_errors):
-                    onboarding_exam = ProctoredExam.objects.filter(course_id=course_id,
-                                                                   is_active=True,
-                                                                   is_practice_exam=True).first()
-                    if onboarding_exam.exists():
+                    onboarding_exam = ProctoredExam.objects.filter(
+                        course_id=course_id, is_active=True, is_practice_exam=True
+                    ).first()
+                    if onboarding_exam:
                         if is_learning_mfe:
                             onboarding_link = resolve_exam_url_for_learning_mfe(
                                 course_id,

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -90,7 +90,8 @@ from edx_proctoring.utils import (
     get_visibility_check_date,
     humanized_time,
     locate_attempt_by_attempt_code,
-    obscured_user_id
+    obscured_user_id,
+    resolve_exam_url_for_learning_mfe
 )
 
 ATTEMPTS_PER_PAGE = 25
@@ -236,6 +237,23 @@ class ProctoredExamAttemptView(ProctoredAPIView):
                 # meaning we do not check prerequisites for practice or onboarding exams
                 elif exam['is_proctored'] and not exam['is_practice_exam']:
                     exam = check_prerequisites(exam, request.user.id)
+
+                # if user hasn't completed required onboarding exam before taking
+                # proctored exam we need to navigate them to it with a link
+                if (exam['is_proctored'] and attempt_data and
+                        attempt_data['attempt_status'] in ProctoredExamStudentAttemptStatus.onboarding_errors):
+                    onboarding_exam = ProctoredExam.objects.filter(course_id=course_id,
+                                                                   is_active=True,
+                                                                   is_practice_exam=True).first()
+                    if onboarding_exam.exists():
+                        if is_learning_mfe:
+                            onboarding_link = resolve_exam_url_for_learning_mfe(
+                                course_id,
+                                onboarding_exam.content_id
+                            )
+                        else:
+                            onboarding_link = reverse('jump_to', args=[course_id, onboarding_exam.content_id])
+                        exam['onboarding_link'] = onboarding_link
                 exam.update({'attempt': attempt_data})
             except ProctoredExamNotFoundException:
                 exam = {}

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -242,6 +242,7 @@ class ProctoredExamAttemptView(ProctoredAPIView):
         if exam:
             provider = get_backend_provider(exam)
             exam['type'] = get_exam_type(exam, provider)['type']
+            exam['passed_due_date'] = is_exam_passed_due(exam, user=request.user.id)
         response_dict = {
             'exam': exam,
             'active_attempt': active_attempt_data,


### PR DESCRIPTION
This PR extends current exam attempt MFE API to return additional data:
1) a link to onboarding exam if user tries to take a proctored exam but hasn't completed required onboarding exam
2) a flag indicating if due date is passed for user to take the exam

[YouTrack](https://youtrack.raccoongang.com/issue/OeX_Proctoring-197)
[JIRA](https://openedx.atlassian.net/browse/EDUCATOR-5808)