### PR TITLE
[BD-26][EDUCATOR-5811] Add total_time and proctoring_escalation_email email to MFE APIs

### DIFF
--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -3105,6 +3105,32 @@ class GetExamAttemptDataTests(ProctoredExamTestCase):
         # make sure we have the accessible human string
         self.assertEqual(data['accessibility_time_string'], 'you have 1 hour and 30 minutes remaining')
 
+    def test_get_exam_attempt_has_total_time_if_status_is_ready_to_resume(self):
+        """
+        Test Case that exam attempt data contains total_time when exam attempt is in ready_to_resume status.
+        """
+        proctored_exam = ProctoredExam.objects.create(
+            course_id='a/b/c',
+            content_id='test_content',
+            exam_name='Test Exam',
+            external_id='123aXqe3',
+            time_limit_mins=90,
+            is_proctored=True,
+        )
+
+        attempt = ProctoredExamStudentAttempt.objects.create(
+            proctored_exam=proctored_exam,
+            user=self.user,
+            allowed_time_limit_mins=90,
+            taking_as_proctored=True,
+            is_sample_attempt=False,
+            external_id=proctored_exam.external_id,
+            status=ProctoredExamStudentAttemptStatus.ready_to_resume
+        )
+
+        data = get_exam_attempt_data(proctored_exam.id, attempt.id)
+        self.assertEqual(data['total_time'], '1 hour and 30 minutes')
+
 
 @ddt.ddt
 class CheckPrerequisitesTests(ProctoredExamTestCase):


### PR DESCRIPTION
Add total_time and proctoring_escalation_email to MFE APIs, this is required for rendering error and ready_to_resume pages for proctored exams

JIRA: [EDUCATOR-5811](https://openedx.atlassian.net/browse/EDUCATOR-5811)