### PR TITLE
[BD-26] Check if exam can be continued whe attempt status is ready_to_submit

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -622,7 +622,6 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
     # a same process as the LMS
     if is_learning_mfe:
         exam_url_path = resolve_exam_url_for_learning_mfe(exam['course_id'], exam['content_id'])
-
     else:
         exam_url_path = reverse('jump_to', args=[exam['course_id'], exam['content_id']])
 
@@ -647,6 +646,12 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
             args=[attempt['id']]
         ),
     }
+
+    if attempt['status'] == ProctoredExamStudentAttemptStatus.ready_to_submit:
+        can_continue = _does_time_remain(attempt)
+        if exam['is_proctored']:
+            can_continue = can_continue and provider and not provider.should_block_access_to_exam_material()
+        attempt_data['can_continue'] = can_continue
 
     if provider:
         attempt_data.update({

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -648,9 +648,8 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
     }
 
     if attempt['status'] == ProctoredExamStudentAttemptStatus.ready_to_submit:
-        can_continue = _does_time_remain(attempt)
-        if exam['is_proctored']:
-            can_continue = can_continue and provider and not provider.should_block_access_to_exam_material()
+        if (can_continue := _does_time_remain(attempt)) and exam['is_proctored']:
+            can_continue = provider and not provider.should_block_access_to_exam_material()
         attempt_data['can_continue'] = can_continue
 
     if provider:

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -3131,6 +3131,19 @@ class GetExamAttemptDataTests(ProctoredExamTestCase):
         data = get_exam_attempt_data(proctored_exam.id, attempt.id)
         self.assertEqual(data['total_time'], '1 hour and 30 minutes')
 
+    @ddt.data('timed_exam_id', 'proctored_exam_id')
+    def test_get_exam_attempt_checks_if_exam_can_be_continued_if_attempt_status_is_ready_to_submit(self, exam_id):
+        """
+        Tests that it is checked whether user can continue taking the exam
+        when attempt is in ready_to_submit status.
+        """
+        attempt = self._create_exam_attempt(
+            getattr(self, exam_id),
+            status=ProctoredExamStudentAttemptStatus.ready_to_submit,
+        )
+        data = get_exam_attempt_data(self.proctored_exam_id, attempt.id)
+        assert 'can_continue' in data
+
 
 @ddt.ddt
 class CheckPrerequisitesTests(ProctoredExamTestCase):


### PR DESCRIPTION
Extend exam attempt API to check if user can continue taking exam when attempt is in ready_to_submit status.

[YouTrack](https://youtrack.raccoongang.com/issue/OeX_Proctoring-234)