### PR TITLE
[BD-26] Calculate correctly total allowed time for exam when time allowance has been added

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -79,6 +79,14 @@ REJECTED_GRADE_OVERRIDE_EARNED = 0.0
 USER_MODEL = get_user_model()
 
 
+def get_total_allowed_time_for_exam(exam, user_id):
+    """
+    Returns total allowed time in humanized form for exam including allowance time.
+    """
+    total_allowed_time = _calculate_allowed_mins(exam, user_id)
+    return humanized_time(total_allowed_time)
+
+
 def get_proctoring_settings_by_exam_id(exam_id):
     """
     Return proctoring settings and exam proctoring backend for proctored exam by exam_id.

--- a/edx_proctoring/tests/test_mfe_views.py
+++ b/edx_proctoring/tests/test_mfe_views.py
@@ -10,9 +10,11 @@ from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 
-from edx_proctoring.api import get_review_policy_by_exam_id
+from edx_proctoring.api import get_exam_by_id, get_review_policy_by_exam_id
 from edx_proctoring.exceptions import BackendProviderNotConfigured, ProctoredExamNotFoundException
+from edx_proctoring.models import ProctoredExamStudentAllowance
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
+from edx_proctoring.utils import humanized_time
 
 from .utils import ProctoredExamTestCase
 
@@ -62,6 +64,25 @@ class ProctoredExamAttemptsMFEViewTests(ProctoredExamTestCase):
         self.assertEqual(exam_data['course_id'], self.course_id)
         self.assertEqual(exam_data['content_id'], self.content_id if not content_id else content_id)
         self.assertEqual(exam_data['time_limit_mins'], self.default_time_limit)
+
+    def test_exam_total_time_with_allowance_time_before_exam_starts(self):
+        """
+        Tests that exam has correct total time when user has additional
+        time allowance and exam has not started yet.
+        """
+        allowed_extra_time = 10
+        ProctoredExamStudentAllowance.objects.create(
+            proctored_exam_id=self.proctored_exam_id,
+            user_id=self.user_id,
+            key=self.key,
+            value=str(allowed_extra_time)
+        )
+        response = self.client.get(self.url)
+        exam = get_exam_by_id(self.proctored_exam_id)
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.content.decode('utf-8'))
+        expected_total_time = humanized_time(exam['time_limit_mins'] + allowed_extra_time)
+        self.assertEqual(response_data['exam']['total_time'], expected_total_time)
 
     def test_get_started_proctored_exam_attempts_data(self):
         """

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -47,6 +47,7 @@ from edx_proctoring.api import (
     get_onboarding_attempt_data_for_learner,
     get_proctoring_settings_by_exam_id,
     get_review_policy_by_exam_id,
+    get_total_allowed_time_for_exam,
     get_user_attempts_by_exam_id,
     is_exam_passed_due,
     mark_exam_attempt_as_ready,
@@ -236,12 +237,17 @@ class ProctoredExamAttemptView(ProctoredAPIView):
                         attempt.get('id'),
                         is_learning_mfe=is_learning_mfe
                     )
-                # Exam hasn't been started yet but it is proctored so needs to be checked
-                # if prerequisites are satisfied. We only do this for proctored exam hence
-                # additional check 'not exam['is_practice_exam']', meaning we do not check
-                # prerequisites for practice or onboarding exams
-                elif exam['is_proctored'] and not exam['is_practice_exam']:
-                    exam = check_prerequisites(exam, request.user.id)
+                else:
+                    # calculate total allowed time for the exam including
+                    # allowance time to show on the MFE entrance pages
+                    exam['total_time'] = get_total_allowed_time_for_exam(exam, request.user.id)
+
+                    # Exam hasn't been started yet but it is proctored so needs to be checked
+                    # if prerequisites are satisfied. We only do this for proctored exam hence
+                    # additional check 'not exam['is_practice_exam']', meaning we do not check
+                    # prerequisites for practice or onboarding exams
+                    if exam['is_proctored'] and not exam['is_practice_exam']:
+                        exam = check_prerequisites(exam, request.user.id)
 
                 # if user hasn't completed required onboarding exam before taking
                 # proctored exam we need to navigate them to it with a link


### PR DESCRIPTION
Calculate correctly total allowed time for exam when time allowance has been added to show on entrance pages of MFE

[YouTrack](https://youtrack.raccoongang.com/issue/OeX_Proctoring-235)