### PR TITLE
[BD-26] Fix generic backend providers to include additional method 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-[3.17.1] - 2021-07-2
+[3.17.3] - 2021-07-14
+~~~~~~~~~~~~~~~~~~~~~
+* Add missing get_proctoring_config method to base backend provider class.
+
+[3.17.2] - 2021-07-2
 ~~~~~~~~~~~~~~~~~~~~~
 * Updated ProctoredExamAttempt view to use the content id from the query.
 

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.17.2'
+__version__ = '3.17.3'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/backends/backend.py
+++ b/edx_proctoring/backends/backend.py
@@ -139,3 +139,9 @@ class ProctoringBackendProvider(metaclass=abc.ABCMeta):
         Returns onboarding profile information for a given course and optional user
         """
         return None
+
+    def get_proctoring_config(self):
+        """
+        Returns the metadata and configuration options for the proctoring service
+        """
+        return None

--- a/edx_proctoring/backends/software_secure.py
+++ b/edx_proctoring/backends/software_secure.py
@@ -390,3 +390,15 @@ class SoftwareSecureBackendProvider(ProctoringBackendProvider):
         req = get_current_request()
         # pylint: disable=illegal-waffle-usage
         return not req.get_signed_cookie('exam', default=False)
+
+    def get_proctoring_config(self):
+        """
+        Returns the metadata and configuration options for the proctoring service
+        """
+        proctoring_config = {
+            'download_url': self.get_software_download_url(),
+            'name': self.verbose_name,
+            'rules': {},
+            'instructions': []
+        }
+        return proctoring_config

--- a/edx_proctoring/backends/tests/test_backend.py
+++ b/edx_proctoring/backends/tests/test_backend.py
@@ -226,6 +226,8 @@ class TestBackends(TestCase):
 
         self.assertIsNone(provider.get_onboarding_profile_info(course_id='test'))
 
+        self.assertIsNone(provider.get_proctoring_config())
+
     def test_null_provider(self):
         """
         Assert that the Null provider does nothing

--- a/edx_proctoring/backends/tests/test_software_secure.py
+++ b/edx_proctoring/backends/tests/test_software_secure.py
@@ -125,6 +125,17 @@ class SoftwareSecureTests(TestCase):
         provider = get_backend_provider()
         self.assertEqual(provider.get_software_download_url(), 'http://example.com')
 
+    def test_get_proctoring_config(self):
+        """
+        Makes sure proctoring config is returned
+        """
+
+        provider = get_backend_provider()
+        config = provider.get_proctoring_config()
+        self.assertIsNotNone(config)
+        self.assertEqual(config['name'], provider.verbose_name)
+        self.assertEqual(config['download_url'], 'http://example.com')
+
     def test_register_attempt(self):
         """
         Makes sure we can register an attempt

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.17.2",
+  "version": "3.17.3",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
Add get_proctoring_config method to generic backend providers, which caused 500 errors for learning mfe

YT: [OeX_Proctoring-283](https://youtrack.raccoongang.com/issue/OeX_Proctoring-283)