### PR TITLE
feat: [Examus-399] change mapping of review statuses to attempt statuses and fix archiving of proctor's review

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '1.5.7'
+__version__ = '1.6.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/signals.py
+++ b/edx_proctoring/signals.py
@@ -117,13 +117,10 @@ def on_review_changed(sender, instance, signal, **kwargs):  # pylint: disable=un
     Archiving all changes made to the Review.
     Will only archive on update/delete, and not on new entries created.
     """
-    if signal is pre_save:
-        if instance.id:
-            # only for update cases
-            instance = sender.objects.get(id=instance.id)
-        else:
-            # don't archive on create
-            return
+    if signal is pre_save and not instance.id:
+        # don't archive on create
+        return
+
     models.archive_model(models.ProctoredExamSoftwareSecureReviewHistory, instance, id='review_id')
 
 

--- a/edx_proctoring/signals.py
+++ b/edx_proctoring/signals.py
@@ -5,7 +5,7 @@ from django.dispatch import receiver
 from edx_proctoring import api
 from edx_proctoring import constants
 from edx_proctoring import models
-from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
+from edx_proctoring.statuses import (ProctoredExamStudentAttemptStatus, SoftwareSecureReviewStatus)
 from edx_proctoring.utils import emit_event, locate_attempt_by_attempt_code
 from edx_proctoring.backends import get_backend_provider
 
@@ -141,6 +141,8 @@ def finish_review_workflow(sender, instance, signal, **kwargs):  # pylint: disab
     # eligibility table
     if review.is_passing:
         attempt_status = ProctoredExamStudentAttemptStatus.verified
+    elif review.review_status == SoftwareSecureReviewStatus.violation:
+        attempt_status = ProctoredExamStudentAttemptStatus.rejected
     elif review.reviewed_by or not constants.REQUIRE_FAILURE_SECOND_REVIEWS:
         # reviews from the django admin have a reviewer set. They should be allowed to
         # reject an attempt

--- a/edx_proctoring/statuses.py
+++ b/edx_proctoring/statuses.py
@@ -151,9 +151,7 @@ class SoftwareSecureReviewStatus(object):
     suspicious = u'Suspicious'
     not_reviewed = u'Not Reviewed'
 
-    passing_statuses = [
-        clean,
-        violation]
+    passing_statuses = (clean, )
     failing_statuses = [
         not_reviewed,
         suspicious]


### PR DESCRIPTION
**Description:**

* changes mapping of review statuses to attempt statuses;
* fixes archiving of proctor's review;
* updates version of `edx-proctoring` plugin from 1.5.7 to 1.6.0.

**YouTrack:** https://youtrack.raccoongang.com/issue/Examus-399

**Related MR:** 
* [examus/edx-platform](https://gitlab.raccoongang.com/hippoteam/examus/edx-platform/-/merge_requests/16)
* [examus/edx-examus-proctoring](https://gitlab.raccoongang.com/rg-developers/edx-examus-proctoring/-/merge_requests/38)

**Merge checklist:**

* [ ] All reviewers approved
* [ ] CI build is green
* [x] Demo status: OK
* [ ] All related documentation is updated
* [ ] DevOps notes added

**Post-Merge:**
* [x] Create `ironwood-v.1.6.0` tag matching the new version number. (Will be made after merge)