### PR TITLE
fix: [EXAM-961] fixed exam sending triggering

### DIFF
--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -23,6 +23,7 @@ from django.shortcuts import redirect
 from django.urls import NoReverseMatch, reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
+from registry_portal.signals import exam_task_reviewed
 
 from edx_proctoring import constants
 from edx_proctoring.api import (
@@ -399,6 +400,10 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
                 attempt['proctored_exam']['id'],
                 request.user.id,
                 ProctoredExamStudentAttemptStatus.submitted
+            )
+            exam_task_reviewed.send(
+                ProctoredExamStudentAttempt,
+                instance=ProctoredExamStudentAttempt.objects.get(id=attempt_id)
             )
         elif action == 'click_download_software':
             exam_attempt_id = update_attempt_status(


### PR DESCRIPTION
**Description:**

This merge request introduces exam task signal triggering when user ends proctoring exam attempt 

**YouTrack:**

[EXAM-961](https://youtrack.raccoongang.com/issue/EXAM-961)

**Pre-Merge Checklist:**

- [x] Demo completed

**Post-Merge:**

- [x] Create a tag matching the new version number.