### PR TITLE
fix: [EXAM-2950] ensure transactional safety for exam attempt state updates

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -12,12 +12,13 @@ from datetime import datetime, timedelta
 
 import pytz
 import six
+from crum import get_current_request
 from waffle import switch_is_active
 
-from crum import get_current_request
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.mail.message import EmailMessage
+from django.db import transaction
 from django.template import loader
 from django.urls import NoReverseMatch, reverse
 from django.utils.translation import ugettext as _
@@ -819,9 +820,17 @@ def _start_exam_attempt(existing_attempt):
 
 def stop_exam_attempt(exam_id, user_id):
     """
-    Marks the exam attempt as completed (sets the completed_at field and updates the record)
+    Mark an attempt as ready to submit unless it is already terminal.
+
+    A stale stop action can arrive after a timeout or submission has already
+    completed the attempt; in that case the terminal status remains unchanged.
     """
-    return update_attempt_status(exam_id, user_id, ProctoredExamStudentAttemptStatus.ready_to_submit)
+    return update_attempt_status(
+        exam_id,
+        user_id,
+        ProctoredExamStudentAttemptStatus.ready_to_submit,
+        skip_if_completed=True,
+    )
 
 
 def mark_exam_attempt_timeout(exam_id, user_id):
@@ -841,76 +850,113 @@ def mark_exam_attempt_as_ready(exam_id, user_id):
 # pylint: disable=inconsistent-return-statements
 def update_attempt_status(exam_id, user_id, to_status,
                           raise_if_not_found=True, cascade_effects=True, timeout_timestamp=None,
-                          update_attributable_to=None):
+                          update_attributable_to=None, skip_if_completed=False):
     """
-    Internal helper to handle state transitions of attempt status
+    Internal helper to handle state transitions of attempt status.
+
+    Serialize writes for one attempt and avoid replaying submission effects.
+
+    ``skip_if_completed`` is intended for stale learner actions whose desired
+    intermediate status must not replace any terminal status. Invalid state
+    changes still raise unless their caller explicitly opts into that policy.
     """
+    with transaction.atomic():
+        try:
+            exam_attempt_obj = ProctoredExamStudentAttempt.objects.select_for_update().get(
+                proctored_exam_id=exam_id,
+                user_id=user_id,
+            )
+        except ProctoredExamStudentAttempt.DoesNotExist:
+            if raise_if_not_found:
+                raise StudentExamAttemptDoesNotExistsException('Error. Trying to look up an exam that does not exist.')
+            return
 
-    exam_attempt_obj = ProctoredExamStudentAttempt.objects.get_exam_attempt(exam_id, user_id)
-    if exam_attempt_obj is None:
-        if raise_if_not_found:
-            raise StudentExamAttemptDoesNotExistsException('Error. Trying to look up an exam that does not exist.')
-        return
+        from_status = exam_attempt_obj.status
 
-    from_status = exam_attempt_obj.status
-
-    log_msg = (
-        u'Updating attempt status for exam_id {exam_id} '
-        u'for user_id {user_id} from status "{from_status}" to "{to_status}"'.format(
-            exam_id=exam_id, user_id=user_id, from_status=from_status, to_status=to_status
+        # In some configuration we may treat timeouts the same
+        # as the user saying he/she wishes to submit the exam.
+        allow_timeout_state = settings.PROCTORING_SETTINGS.get('ALLOW_TIMED_OUT_STATE', False)
+        treat_timeout_as_submitted = (
+            to_status == ProctoredExamStudentAttemptStatus.timed_out and not allow_timeout_state
         )
-    )
-    log.info(log_msg)
-    # In some configuration we may treat timeouts the same
-    # as the user saying he/she wishes to submit the exam
-    allow_timeout_state = settings.PROCTORING_SETTINGS.get('ALLOW_TIMED_OUT_STATE', False)
-    treat_timeout_as_submitted = to_status == ProctoredExamStudentAttemptStatus.timed_out and not allow_timeout_state
 
-    user_trying_to_reattempt = is_reattempting_exam(from_status, to_status)
-    if treat_timeout_as_submitted or user_trying_to_reattempt:
-        to_status = ProctoredExamStudentAttemptStatus.submitted
+        user_trying_to_reattempt = is_reattempting_exam(from_status, to_status)
+        if treat_timeout_as_submitted or user_trying_to_reattempt:
+            to_status = ProctoredExamStudentAttemptStatus.submitted
 
-    exam = get_exam_by_id(exam_id)
-    # don't allow state transitions from a completed state to an incomplete state
-    # if a re-attempt is desired then the current attempt must be deleted
-    #
-    in_completed_status = ProctoredExamStudentAttemptStatus.is_completed_status(from_status)
-    to_incompleted_status = ProctoredExamStudentAttemptStatus.is_incomplete_status(to_status)
+        if (
+                from_status == ProctoredExamStudentAttemptStatus.submitted and
+                to_status == ProctoredExamStudentAttemptStatus.submitted
+        ):
+            return exam_attempt_obj.id
 
-    if in_completed_status and to_incompleted_status:
-        err_msg = (
-            u'A status transition from {from_status} to {to_status} was attempted '
-            u'on exam_id {exam_id} for user_id {user_id}. This is not '
-            u'allowed!'.format(
-                from_status=from_status,
-                to_status=to_status,
-                exam_id=exam_id,
-                user_id=user_id
+        in_completed_status = ProctoredExamStudentAttemptStatus.is_completed_status(from_status)
+        if skip_if_completed and in_completed_status and from_status != to_status:
+            log.info(
+                'Ignoring stale status update for exam_id %d and user_id %d: '
+                'current status "%s", requested status "%s".',
+                exam_id,
+                user_id,
+                from_status,
+                to_status,
+            )
+            return exam_attempt_obj.id
+
+        exam = get_exam_by_id(exam_id)
+        log_msg = (
+            'Updating attempt status for exam_id {exam_id} '
+            'for user_id {user_id} from status "{from_status}" to "{to_status}"'.format(
+                exam_id=exam_id, user_id=user_id, from_status=from_status, to_status=to_status
             )
         )
-        raise ProctoredExamIllegalStatusTransition(err_msg)
+        log.info(log_msg)
+        # Do not allow state transitions from a completed state to an incomplete state.
+        # If a re-attempt is desired then the current attempt must be deleted.
+        to_incompleted_status = ProctoredExamStudentAttemptStatus.is_incomplete_status(to_status)
 
-    # OK, state transition is fine, we can proceed
-    exam_attempt_obj.status = to_status
+        if in_completed_status and to_incompleted_status:
+            err_msg = (
+                'A status transition from {from_status} to {to_status} was attempted '
+                'on exam_id {exam_id} for user_id {user_id}. This is not '
+                'allowed!'.format(
+                    from_status=from_status,
+                    to_status=to_status,
+                    exam_id=exam_id,
+                    user_id=user_id
+                )
+            )
+            raise ProctoredExamIllegalStatusTransition(err_msg)
 
-    # if we have transitioned to started and haven't set our
-    # started_at timestamp and calculate allowed minutes, do so now
-    add_start_time = (
-        to_status == ProctoredExamStudentAttemptStatus.started and
-        not exam_attempt_obj.started_at
-    )
-    if add_start_time:
-        exam_attempt_obj.started_at = datetime.now(pytz.UTC)
-        exam_attempt_obj.allowed_time_limit_mins = _calculate_allowed_mins(exam, exam_attempt_obj.user_id)
+        # OK, state transition is fine, we can proceed.
+        exam_attempt_obj.status = to_status
 
-    elif treat_timeout_as_submitted:
-        exam_attempt_obj.completed_at = timeout_timestamp
-    elif to_status in (ProctoredExamStudentAttemptStatus.submitted, ProctoredExamStudentAttemptStatus.declined):
-        # likewise, when we transit to submitted or declined mark
-        # when the exam has been completed
-        exam_attempt_obj.completed_at = datetime.now(pytz.UTC)
+        # If we have transitioned to started and have not set our
+        # started_at timestamp and calculated allowed minutes, do so now.
+        add_start_time = (
+            to_status == ProctoredExamStudentAttemptStatus.started and
+            not exam_attempt_obj.started_at
+        )
+        if add_start_time:
+            exam_attempt_obj.started_at = datetime.now(pytz.UTC)
+            exam_attempt_obj.allowed_time_limit_mins = _calculate_allowed_mins(exam, exam_attempt_obj.user_id)
 
-    exam_attempt_obj.save()
+        elif treat_timeout_as_submitted:
+            exam_attempt_obj.completed_at = timeout_timestamp
+        elif to_status in (ProctoredExamStudentAttemptStatus.submitted, ProctoredExamStudentAttemptStatus.declined):
+            # Likewise, when we transit to submitted or declined mark
+            # when the exam has been completed.
+            exam_attempt_obj.completed_at = datetime.now(pytz.UTC)
+
+        if (
+                cascade_effects and
+                to_status == ProctoredExamStudentAttemptStatus.declined
+        ):
+            # Clear backend fields in the same write as the status change so
+            # deletion cannot interleave between two writes to this attempt.
+            exam_attempt_obj.taking_as_proctored = False
+            exam_attempt_obj.external_id = None
+
+        exam_attempt_obj.save()
 
     # make sure that attempt to pass timed exam hasn't ended in failure (incomplete state),
     # else update status of exam attempt
@@ -961,13 +1007,6 @@ def update_attempt_status(exam_id, user_id, to_status,
         )
 
     if cascade_effects and ProctoredExamStudentAttemptStatus.is_a_cascadable_failure(to_status):
-        if to_status == ProctoredExamStudentAttemptStatus.declined:
-            # if user declines attempt, make sure we clear out the external_id and
-            # taking_as_proctored fields
-            exam_attempt_obj.taking_as_proctored = False
-            exam_attempt_obj.external_id = None
-            exam_attempt_obj.save()
-
         # some state transitions (namely to a rejected or declined status)
         # will mark other exams as declined because once we fail or decline
         # one exam all other (un-completed) proctored exams will be likewise
@@ -1223,26 +1262,32 @@ def remove_exam_attempt(attempt_id, requesting_user):
     """
 
     log_msg = (
-        u'Removing exam attempt {attempt_id}'.format(attempt_id=attempt_id)
+        'Removing exam attempt {attempt_id}'.format(attempt_id=attempt_id)
     )
     log.info(log_msg)
 
-    existing_attempt = ProctoredExamStudentAttempt.objects.get_exam_attempt_by_id(attempt_id)
-    if not existing_attempt:
-        err_msg = (
-            u'Cannot remove attempt for attempt_id = {attempt_id} '
-            u'because it does not exist!'
-        ).format(attempt_id=attempt_id)
+    with transaction.atomic():
+        try:
+            existing_attempt = (
+                ProctoredExamStudentAttempt.objects.select_for_update().get(id=attempt_id)
+            )
+        except ProctoredExamStudentAttempt.DoesNotExist:
+            err_msg = (
+                'Cannot remove attempt for attempt_id = {attempt_id} '
+                'because it does not exist!'
+            ).format(attempt_id=attempt_id)
 
-        raise StudentExamAttemptDoesNotExistsException(err_msg)
+            raise StudentExamAttemptDoesNotExistsException(err_msg)
 
-    username = existing_attempt.user.username
-    user_id = existing_attempt.user.id
-    course_id = existing_attempt.proctored_exam.course_id
-    content_id = existing_attempt.proctored_exam.content_id
-    to_status = existing_attempt.status
+        username = existing_attempt.user.username
+        user_id = existing_attempt.user.id
+        course_id = existing_attempt.proctored_exam.course_id
+        content_id = existing_attempt.proctored_exam.content_id
+        to_status = existing_attempt.status
 
-    existing_attempt.delete_exam_attempt()
+        # Use the same attempt row lock as status updates before archiving and deleting.
+        existing_attempt.delete_exam_attempt()
+
     instructor_service = get_runtime_service('instructor')
     grades_service = get_runtime_service('grades')
 

--- a/edx_proctoring/tasks.py
+++ b/edx_proctoring/tasks.py
@@ -1,12 +1,13 @@
 """
 Celery tasks for edx-proctoring.
 """
+
 import logging
+from importlib import import_module
+from typing import Optional
 
 from celery.task import task
 
-from edx_proctoring import api
-from edx_proctoring.exceptions import StudentExamAttemptDoesNotExistsException
 from edx_proctoring.models import ProctoredExamStudentAttempt
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 
@@ -14,14 +15,20 @@ log = logging.getLogger('edx.celery.task')
 
 
 @task(bind=True)
-def complete_exam_if_attempt_fails(self, attempt_id):
+def complete_exam_if_attempt_fails(self, attempt_id: int) -> Optional[None]:
     """
     Fix status of attempt in completed state if timed exam has ended in failure.
 
     Check attempt after timed exam is finished. If its status is in incomplete state
-    (e.g. started. ready_to_submit, ready_to_decline) that update it to completed state
+    (e.g. started, ready_to_submit, ready_to_decline) then update it to completed state
     (e.g. submitted, declined).
+
+    :param attempt_id: The ID of the proctored exam attempt to check and potentially update
+    :return: None
     """
+    # ``api.py`` schedules this task, so defer the reverse import until execution.
+    api = import_module('edx_proctoring.api')
+
     log.info(
         'Checking status of attempt %d after timed exam is finished.',
         attempt_id,
@@ -29,21 +36,33 @@ def complete_exam_if_attempt_fails(self, attempt_id):
     exam_attempt = ProctoredExamStudentAttempt.objects.get_exam_attempt_by_id(attempt_id)
 
     if not exam_attempt:
-        err_msg = ('Attempted to access to exam attempt {0} but it does not exist.'.format(attempt_id))
-        raise StudentExamAttemptDoesNotExistsException(err_msg)
+        log.info(
+            'Skipping completion check for attempt %d because it no longer exists.',
+            attempt_id,
+        )
+        return
 
     if exam_attempt.status in ProctoredExamStudentAttemptStatus.failed_exam_end_states:
         try:
-            api.update_attempt_status(
+            updated_attempt_id = api.update_attempt_status(
                 exam_attempt.proctored_exam_id,
                 exam_attempt.user_id,
                 to_status=ProctoredExamStudentAttemptStatus.convert_to_completed_state(exam_attempt.status),
+                raise_if_not_found=False,
+                skip_if_completed=True,
             )
         except Exception as exc:
             log.exception('Retrying updating of exam attempt %d to completed state: %s.', attempt_id, exc)
             raise self.retry(exc=exc)
 
         else:
+            if updated_attempt_id is None:
+                log.info(
+                    'Skipping completion check for attempt %d because it was removed during processing.',
+                    attempt_id,
+                )
+                return
+
             log.info(
                 'Updating of exam attempt %d from status "%s" to "%s" is completed.',
                 attempt_id,

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -638,7 +638,8 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         attempt = self._create_unstarted_exam_attempt()
         start_exam_attempt_by_code(attempt.attempt_code)
 
-    def test_restart_a_started_attempt(self):
+    @patch('edx_proctoring.api.complete_exam_if_attempt_fails.apply_async')
+    def test_restart_a_started_attempt(self, mocked_apply_async):
         """
         Test to attempt starting an attempt which has been created but not started.
         """
@@ -646,6 +647,7 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         start_exam_attempt(self.proctored_exam_id, self.user_id)
         with self.assertRaises(StudentExamAttemptedAlreadyStarted):
             start_exam_attempt(self.proctored_exam_id, self.user_id)
+        mocked_apply_async.assert_called_once()
 
     def test_stop_exam_attempt(self):
         """
@@ -657,6 +659,23 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
             proctored_exam_student_attempt.proctored_exam.id, self.user_id
         )
         self.assertEqual(proctored_exam_student_attempt.id, proctored_exam_attempt_id)
+
+    def test_stop_completed_attempt_is_idempotent(self):
+        """
+        Keep a submitted attempt terminal when a stale stop request arrives.
+        """
+        exam_attempt = self._create_started_exam_attempt(is_proctored=False)
+        update_attempt_status(
+            exam_attempt.proctored_exam_id,
+            self.user.id,
+            ProctoredExamStudentAttemptStatus.submitted,
+        )
+
+        attempt_id = stop_exam_attempt(exam_attempt.proctored_exam_id, self.user.id)
+        exam_attempt.refresh_from_db()
+
+        self.assertEqual(attempt_id, exam_attempt.id)
+        self.assertEqual(exam_attempt.status, ProctoredExamStudentAttemptStatus.submitted)
 
     def test_remove_exam_attempt(self):
         """
@@ -891,6 +910,35 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
             credit_status['credit_requirement_status'][0]['status'],
             'submitted'
         )
+
+    @freeze_time("2026-01-01 00:00:00")
+    def test_repeated_status_update_does_not_rewrite_attempt(self):
+        """
+        Avoid rewriting an attempt or replaying effects when submission is retried.
+        """
+        exam_attempt = self._create_started_exam_attempt(is_proctored=False)
+        credit_service = get_runtime_service('credit')
+        update_attempt_status(
+            exam_attempt.proctored_exam_id,
+            self.user.id,
+            ProctoredExamStudentAttemptStatus.submitted,
+        )
+        exam_attempt.refresh_from_db()
+        completed_at = exam_attempt.completed_at
+        modified = exam_attempt.modified
+        credit_update_count = credit_service.order
+
+        with freeze_time("2026-01-02 00:00:00"):
+            update_attempt_status(
+                exam_attempt.proctored_exam_id,
+                self.user.id,
+                ProctoredExamStudentAttemptStatus.submitted,
+            )
+        exam_attempt.refresh_from_db()
+
+        self.assertEqual(exam_attempt.completed_at, completed_at)
+        self.assertEqual(exam_attempt.modified, modified)
+        self.assertEqual(credit_service.order, credit_update_count)
 
     def test_error_credit_state(self):
         """

--- a/edx_proctoring/tests/test_tasks.py
+++ b/edx_proctoring/tests/test_tasks.py
@@ -1,0 +1,43 @@
+"""
+Tests for Celery tasks in ``edx_proctoring.tasks``.
+"""
+
+from __future__ import absolute_import
+
+from mock import patch
+
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
+from edx_proctoring.tasks import complete_exam_if_attempt_fails
+
+from .utils import ProctoredExamTestCase
+
+
+class CompleteExamIfAttemptFailsTests(ProctoredExamTestCase):
+    """
+    Regression tests for completion checks scheduled after timed exams.
+    """
+
+    def test_missing_attempt_is_ignored(self):
+        """
+        Ignore a task whose active attempt was already removed.
+        """
+        self.assertIsNone(complete_exam_if_attempt_fails.run(attempt_id=9999))
+
+    @patch("edx_proctoring.api.update_attempt_status")
+    def test_attempt_removed_during_update_is_ignored(self, mocked_update_attempt_status):
+        """
+        Ignore deletion that occurs between lookup and status update.
+        """
+        exam_attempt = self._create_started_exam_attempt(is_proctored=False)
+        mocked_update_attempt_status.return_value = None
+
+        result = complete_exam_if_attempt_fails.run(attempt_id=exam_attempt.id)
+
+        self.assertIsNone(result)
+        mocked_update_attempt_status.assert_called_once_with(
+            exam_attempt.proctored_exam_id,
+            exam_attempt.user_id,
+            to_status=ProctoredExamStudentAttemptStatus.submitted,
+            raise_if_not_found=False,
+            skip_if_completed=True,
+        )

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -1191,7 +1191,42 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
             content_type='application/json'
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 200)
+        attempt = get_exam_attempt_by_id(old_attempt_id)
+        self.assertEqual(attempt['status'], expected_status)
+
+    def test_confirm_submission_after_submit_is_idempotent(self):
+        """
+        Ignore a confirmation PUT that arrives after submission has completed.
+        """
+        exam = ProctoredExam.objects.create(
+            course_id="a/b/c",
+            content_id="test_content",
+            exam_name="Test Exam",
+            external_id="123aXqe3",
+            time_limit_mins=90,
+            is_proctored=False,
+            backend="null",
+        )
+        attempt_id = create_exam_attempt(exam.id, self.user.id, False)
+        attempt = get_exam_attempt_by_id(attempt_id)
+        url = reverse("edx_proctoring:proctored_exam.attempt", args=[attempt["id"]])
+
+        submit_response = self.client.put(
+            url,
+            json.dumps({"action": "submit"}),
+            content_type="application/json"
+        )
+        confirm_response = self.client.put(
+            url,
+            json.dumps({"action": "confirm_submission"}),
+            content_type="application/json"
+        )
+
+        self.assertEqual(submit_response.status_code, 200)
+        self.assertEqual(confirm_response.status_code, 200)
+        attempt = get_exam_attempt_by_id(attempt["id"])
+        self.assertEqual(attempt["status"], ProctoredExamStudentAttemptStatus.submitted)
 
     @patch('edx_proctoring.views.waffle.switch_is_active')
     def test_attempt_ping_failure_when_submitted(self, mocked_switch_is_active):

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -19,6 +19,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.db import transaction
 from django.shortcuts import redirect
 from django.urls import NoReverseMatch, reverse
 from django.utils.decorators import method_decorator
@@ -288,6 +289,7 @@ class ProctoredExamView(ProctoredAPIView):
         return Response(data)
 
 
+@method_decorator(transaction.non_atomic_requests, name="dispatch")
 class StudentProctoredExamAttempt(ProctoredAPIView):
     """
     Endpoint for the StudentProctoredExamAttempt
@@ -399,6 +401,8 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
                 attempt['proctored_exam']['id'],
                 request.user.id,
                 ProctoredExamStudentAttemptStatus.confirmed_submission,
+                # Submission or timeout can win a race with this stale UI action.
+                skip_if_completed=True,
             )
         elif action == 'submit':
             exam_attempt_id = update_attempt_status(

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,6 +2,7 @@
 -c constraints.txt
 
 # Django/Framework Packages
+celery==3.1.26.post2      # Match the Celery version provided by Open edX Juniper.
 Django>=2.2
 django-model-utils
 djangorestframework
@@ -21,4 +22,3 @@ edx-opaque-keys>=0.4
 edx-drf-extensions
 edx-rest-api-client>=1.9.2
 edx-when>=0.1.3
-

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,8 +4,12 @@
 #
 #    make upgrade
 #
+amqp==1.4.9               # via kombu
+anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via fs
+billiard==3.3.0.23        # via celery
 certifi==2020.4.5.1       # via requests
+celery==3.1.26.post2      # via -r requirements/base.in
 chardet==3.0.4            # via requests
 django-crum==0.7.6        # via -r requirements/base.in
 django-ipware==2.1.0      # via -r requirements/base.in
@@ -25,6 +29,7 @@ fs==2.4.11                # via xblock
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in
+kombu==3.0.37             # via celery
 lxml==4.5.0               # via xblock
 markupsafe==1.1.1         # via xblock
 newrelic==5.12.0.140      # via edx-django-utils

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,11 +4,15 @@
 #
 #    make upgrade
 #
+amqp==1.4.9               # via kombu
+anyjson==0.3.3            # via kombu
 apipkg==1.5               # via execnet
 appdirs==1.4.3            # via fs
 attrs==19.3.0             # via pytest
+billiard==3.3.0.23        # via celery
 bok-choy==1.0.1           # via -r requirements/test.in
 certifi==2020.4.5.1       # via requests
+celery==3.1.26.post2      # via -r requirements/base.in
 chardet==3.0.4            # via requests
 click==7.1.2              # via code-annotations
 code-annotations==0.3.3   # via -r requirements/test.in
@@ -37,6 +41,7 @@ idna==2.9                 # via requests
 importlib-metadata==1.6.0  # via path, pluggy, pytest
 jinja2==2.11.2            # via code-annotations
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in
+kombu==3.0.37             # via celery
 lazy==1.4                 # via bok-choy
 logilab-common==1.5.2     # via -r requirements/test.in
 lxml==4.5.0               # via xblock


### PR DESCRIPTION
**Description:**
* ensure transactional safety for exam attempt state updates to prevent race conditions
* handle missing or removed exam attempts gracefully
* add regression tests for handling stale or idempotent exam updates

**YouTrack:** https://youtrack.raccoongang.com/issue/EXAM-2950

**Merge checklist:**
* [x] Demo status: OK

**Post-Merge:**
* [ ] Create `ukr-sertification-juniper-v.2.10.8` tag matching the new version number. (Will be made after merge)