### PR TITLE
fix: [EXAM-2950] complete_exam_if_attempt_fails task schedules only if previous attempt status is created

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -958,11 +958,12 @@ def update_attempt_status(exam_id, user_id, to_status,
 
         exam_attempt_obj.save()
 
-    # make sure that attempt to pass timed exam hasn't ended in failure (incomplete state),
-    # else update status of exam attempt
+    # Verify that the timed exam attempt hasn't ended in an incomplete state
+    # and schedule a background task to update its status if needed
     if (
             exam_attempt_obj.status == ProctoredExamStudentAttemptStatus.started and
-            exam_attempt_obj.allowed_time_limit_mins
+            exam_attempt_obj.allowed_time_limit_mins and
+            ProctoredExamStudentAttemptStatus.is_pre_started_status(from_status)
     ):
         complete_exam_if_attempt_fails.apply_async(
             countdown=timedelta(

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
@@ -97,7 +97,7 @@ edx = edx || {};
             this.render();
         },
         render: function() {
-            var html, self, $end_exam_btn;
+            var html, self, $end_exam_btn, $cancel_exam_btn;
             if (this.template !== null) {
                 if (
                     this.model.get('in_timed_exam') &&
@@ -164,7 +164,8 @@ edx = edx || {};
                         }
                     });
 
-                    $('.exam-button-cancel-in-exam').click(function() {
+                    $cancel_exam_btn = $('.exam-button-cancel-in-exam');
+                    $cancel_exam_btn.click(function() {
                         $(window).unbind('beforeunload', self.unloadMessage);
 
                         var $nextQuestionBtn = $('.next-btn'),
@@ -180,6 +181,7 @@ edx = edx || {};
                         } else if ( $stopRecordingBtn.closest('.tab').css('display') === 'block' && !$stopRecordingBtn.prop('disabled') ) {
                             window.alert(needToSubmitAnswerMessage);
                         } else {
+                            $cancel_exam_btn.attr('disabled', 'disabled').addClass('disabled');
                             $.ajax({
                                 url: '/api/edx_proctoring/v1/proctored_exam/attempt/' + self.model.get('attempt_id'),
                                 type: 'PUT',
@@ -190,6 +192,9 @@ edx = edx || {};
                                     // change the location of the page to the active exam page
                                     // which will reflect the new state of the attempt
                                     location.href = self.model.get('exam_url_path');
+                                },
+                                error: function(data) {
+                                    $cancel_exam_btn.removeAttr('disabled').removeClass('disabled');
                                 }
                             });
                             // Generate event for button click to keep student answer


### PR DESCRIPTION
**Description:**
* complete_exam_if_attempt_fails task schedules only if previous attempt status is created
* disable cancel button during exam attempt API call

**YouTrack:** https://youtrack.raccoongang.com/issue/EXAM-2950

**Merge checklist:**
* [x] Demo status: OK

**Post-Merge:**
* [ ] Create `ukr-sertification-juniper-v.2.10.10` tag matching the new version number. (Will be made after merge)