### PR TITLE
fix: [EXAM-2964] fix proctored exam routing key fallback

### DIFF
--- a/edx_proctoring/settings/production.py
+++ b/edx_proctoring/settings/production.py
@@ -7,11 +7,7 @@ def plugin_settings(settings):
     env_tokens = getattr(settings, 'ENV_TOKENS', {})
     settings.PROCTORED_EXAM_ATTEMPT_REMOVAL_ROUTING_KEY = env_tokens.get(
         'PROCTORED_EXAM_ATTEMPT_REMOVAL_ROUTING_KEY',
-        getattr(
-            settings,
-            'PROCTORED_EXAM_ATTEMPT_REMOVAL_ROUTING_KEY',
-            getattr(settings, 'HIGH_MEM_QUEUE', None),
-        ),
+        getattr(settings, 'HIGH_MEM_QUEUE', None),
     )
     if env_tokens.get('PROCTORING_SETTINGS'):
         settings.PROCTORING_SETTINGS = env_tokens['PROCTORING_SETTINGS']


### PR DESCRIPTION
**Description:**
* fix proctored exam routing key fallback

**YouTrack:** https://youtrack.raccoongang.com/issue/EXAM-2964

**Merge checklist:**
* [x] Demo status: OK

**Post-Merge:**
* [ ] Create `ukr-sertification-juniper-v.2.10.13` tag matching the new version number. (Will be made after merge)